### PR TITLE
Making default margin optional for sub-routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Block-slot will yield back a hash containing contextual components which you can
 {{#routes.related 'details.related.friends' icon='tenant'}}Friends{{/routes.related}}
 {{#routes.related 'details.related.subscriptions' icon='service'}}Subs{{/routes.related}}
 ```
+### Styles
+Default styles can be applied to your sub-routes.
+
+##### Default Margin
+To get a default margin for your content area, add the 'frost-object-browser__content' class to your template.
+```handlebars
+<div class="frost-object-details__content" style="background-color: skyblue; height: 600px">
+    This is profile template
+</div>
+```
 
 ## Development
 ### Setup

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -33,9 +33,11 @@
     flex-direction: row;
     flex: 1;
 
-    > .content {
+    > .main-container {
       flex: 1;
-      margin: 20px 0 0 20px;
+      .frost-object-details__content {
+        margin: 20px 0 0 20px;
+      }
     }
 
     > .related-tabs {

--- a/addon/templates/components/frost-object-details.hbs
+++ b/addon/templates/components/frost-object-details.hbs
@@ -6,9 +6,7 @@
   {{/yield-slot}}
 </div>
 <div class="body">
-    <div class="content">
-      {{liquid-outlet class='main-container'}}
-    </div>
+    {{liquid-outlet class='main-container'}}
     <div class="related-tabs">
       {{#yield-slot 'related-route'}}
         {{yield (block-params (hash

--- a/tests/dummy/app/pods/details/views/profile/template.hbs
+++ b/tests/dummy/app/pods/details/views/profile/template.hbs
@@ -1,3 +1,3 @@
-<div style="background-color: skyblue; height: 600px">
+<div class="frost-object-details__content" style="background-color: skyblue; height: 600px">
     This is profile template
 </div>


### PR DESCRIPTION
#fix#

# CHANGELOG

Removing the default margin on the content area, leaving this specification to the discretion of the implementor