### PR TITLE
Fixing issues with liquid-bind => content component destruction

### DIFF
--- a/addon/components/frost-object-details.js
+++ b/addon/components/frost-object-details.js
@@ -4,8 +4,6 @@ import layout from '../templates/components/frost-object-details'
 import PropTypesMixin, { PropTypes } from 'ember-prop-types'
 import uuid from 'ember-simple-uuid'
 
-
-
 export default Component.extend(PropTypesMixin, {
   // == Component properties ==================================================
 

--- a/addon/components/frost-object-details.js
+++ b/addon/components/frost-object-details.js
@@ -1,12 +1,10 @@
 import Ember from 'ember'
+const {Component, computed, get, set} = Ember
 import layout from '../templates/components/frost-object-details'
 import PropTypesMixin, { PropTypes } from 'ember-prop-types'
 import uuid from 'ember-simple-uuid'
 
-const {
-  Component,
-  computed
-} = Ember
+
 
 export default Component.extend(PropTypesMixin, {
   // == Component properties ==================================================
@@ -16,6 +14,7 @@ export default Component.extend(PropTypesMixin, {
 
   // == State properties ======================================================
   orderedTabIds: [],
+  tabTypeMap: {},
 
   propTypes: {
     selectedTabId: PropTypes.string.isRequired,
@@ -42,10 +41,57 @@ export default Component.extend(PropTypesMixin, {
    */
   registerTab: computed(function () {
     return (function () {
-      return (id) => {
+      return (id, type) => {
         this.get('orderedTabIds').push(id)
+        set(this.get('tabTypeMap'), id, type)
       }
     }.call(this))
+  }),
+
+  animations: computed(function () {
+    const orderedTabIds = this.get('orderedTabIds')
+    const tabTypeMap = this.get('tabTypeMap')
+    const detailTabType = 'tab'
+
+    return function () {
+      this.transition(
+        this.toValue(function (toValue, fromValue) {
+          const tabType = get(tabTypeMap, toValue)
+
+          return orderedTabIds &&
+            tabType === detailTabType &&
+            orderedTabIds.indexOf(fromValue) > orderedTabIds.indexOf(toValue)
+        }),
+        this.use('to-left')
+      )
+
+      this.transition(
+        this.toValue(function (toValue, fromValue) {
+          const tabType = get(tabTypeMap, toValue)
+
+          return orderedTabIds &&
+            tabType === detailTabType &&
+            orderedTabIds.indexOf(fromValue) < orderedTabIds.indexOf(toValue)
+        }),
+        this.use('to-right')
+      )
+
+      this.transition(
+        this.toValue(function (toValue, fromValue) {
+          return get(tabTypeMap, toValue) !== detailTabType && fromValue !== toValue
+        }),
+        this.use('to-up')
+      )
+
+      this.transition(
+        this.toValue(function (toValue, fromValue) {
+          return get(tabTypeMap, fromValue) !== detailTabType &&
+            get(tabTypeMap, fromValue) !== get(tabTypeMap, toValue) &&
+            fromValue !== toValue
+        }),
+        this.use('to-down')
+      )
+    }
   }),
 
   // == Actions ===============================================================
@@ -61,47 +107,8 @@ export default Component.extend(PropTypesMixin, {
         this.onChange(id, type)
       }
     }
-  },
+  }
 
   // == Functions ==============================================================
 
-  animations () {
-    const detailTabType = 'tab'
-    this.transition(
-      this.toValue(function (toValue, fromValue) {
-        const tabIds = toValue.orderedTabIds
-        const tabType = toValue.tab.type
-
-        return tabIds &&
-          tabType === detailTabType &&
-          tabIds.indexOf(fromValue.tab.id) > tabIds.indexOf(toValue.tab.id)
-      }),
-      this.use('to-left')
-    )
-    this.transition(
-      this.toValue(function (toValue, fromValue) {
-        const tabIds = toValue.orderedTabIds
-        const tabType = toValue.tab.type
-
-        return tabIds &&
-          tabType === detailTabType &&
-          tabIds.indexOf(fromValue.tab.id) < tabIds.indexOf(toValue.tab.id)
-      }),
-      this.use('to-right')
-    )
-    this.transition(
-      this.toValue(function (toValue, fromValue) {
-        return toValue.tab.type !== detailTabType && fromValue.tab.id !== toValue.tab.id
-      }),
-      this.use('to-up')
-    )
-    this.transition(
-      this.toValue(function (toValue, fromValue) {
-        return fromValue.tab.type !== detailTabType &&
-          fromValue.tab.type !== toValue.tab.type &&
-          fromValue.tab.id !== toValue.tab.id
-      }),
-      this.use('to-down')
-    )
-  }
 })

--- a/addon/components/frost-object-tab.js
+++ b/addon/components/frost-object-tab.js
@@ -60,11 +60,11 @@ export default Component.extend(PropTypesMixin, {
   // == Events ================================================================
 
   /**
-   * Register the id of the tab during init.
+   * Register the id and type of the tab during init.
    */
   _register: Ember.on('init', function () {
     if (typeof this.register === 'function') {
-      this.register(this.id)
+      this.register(this.id, this.type)
     }
   }),
 

--- a/addon/templates/components/frost-object-details.hbs
+++ b/addon/templates/components/frost-object-details.hbs
@@ -19,8 +19,8 @@
   <div class='object-details-body'>
     <div class='content' data-test={{hook (concat hook '-object-details-body-content')}}>
       {{#from-elsewhere name=targetOutlet as |tab|}}
-        {{#liquid-bind (hash tab=tab orderedTabIds=orderedTabIds) rules=animations as |currentModel|}}
-          {{component currentModel.tab.content}}
+        {{#liquid-bind tab.id rules=animations}}
+          {{component tab.content}}
         {{/liquid-bind}}
       {{/from-elsewhere}}
     </div>

--- a/tests/dummy/app/pods/demo/content/controller.js
+++ b/tests/dummy/app/pods/demo/content/controller.js
@@ -2,10 +2,28 @@ import Ember from 'ember'
 
 // BEGIN-SNIPPET content-controller
 export default Ember.Controller.extend({
+  queryParams: ['filter'],
+
+  filter: '',
+  filterA: '',
+  filterB: '',
+
   actions: {
     onChange (id, type) {
       this.set('selectedTabId', id)
       this.set('selectedTabType', type)
+    },
+
+    onFilterChange (event) {
+      this.set('filter', event.value)
+    },
+
+    onFilterChangeA (event) {
+      this.set('filterA', event.value)
+    },
+
+    onFilterChangeB (event) {
+      this.set('filterB', event.value)
     }
   }
 })

--- a/tests/dummy/app/pods/demo/content/template.hbs
+++ b/tests/dummy/app/pods/demo/content/template.hbs
@@ -69,9 +69,26 @@
         (component 'frost-object-tab'
           id='profile'
           text='Profile View'
-          content=(component 'object-details-content'
-            color='skyblue'
-            name='profile')
+          content=(component 'frost-text'
+            onInput=(action 'onFilterChange')
+            value=filter
+          )
+        )
+        (component 'frost-object-tab'
+          id='foo'
+          text='Foo'
+          content=(component 'frost-text'
+            onInput=(action 'onFilterChangeA')
+            value=filterA
+          )
+        )
+        (component 'frost-object-tab'
+          id='bar'
+          text='Bar'
+          content=(component 'frost-text'
+            onInput=(action 'onFilterChangeB')
+            value=filterB
+          )
         )
       )
       relatedObjectTabs=(array
@@ -85,6 +102,17 @@
           content=(component 'object-details-content'
             color='coral'
             name='related devices')
+        )
+        (component 'frost-related-object-tab'
+          id='baz'
+          text='Baz'
+          icon=(hash
+            name='service'
+            pack='dummy'
+          )
+          content=(component 'object-details-content'
+            color='rebeccapurple'
+            name='related baz')
         )
       )
     }}

--- a/tests/integration/components/frost-object-details-test.js
+++ b/tests/integration/components/frost-object-details-test.js
@@ -286,7 +286,7 @@ describeComponent(
           defaultTabId=defaultTabId
           detailTabs=(array
             (component 'frost-object-tab'
-              id=selectedTabId
+              id='profile'
               text='Profile View'
               content=(component 'object-details-content' color='skyblue' name=selectedTabName)
             )
@@ -313,7 +313,7 @@ describeComponent(
           defaultTabId=defaultTabId
           detailTabs=(array
             (component 'frost-object-tab'
-              id=selectedTabId
+              id='profile'
               text='Profile View'
               content=(component 'object-details-content' color='skyblue' name=selectedTabName)
             )


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Not my cleanest work, but this fixes the issue

# CHANGELOG
* Passing a complex object to liquid-bind caused an over-aggressive destruction of content components, fixed the liquid-bind to use a simple property and passed other values required for animation matches via registration
