### PR TITLE
Update usage of deprecated ember-mocha describeComponent()

### DIFF
--- a/tests/integration/components/frost-object-details-test.js
+++ b/tests/integration/components/frost-object-details-test.js
@@ -1,16 +1,11 @@
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
-import { beforeEach } from 'mocha'
+import {expect} from 'chai'
+import {$hook, initialize as initializeHook} from 'ember-hook'
 import hbs from 'htmlbars-inline-precompile'
-import {
-  $hook,
-  initialize as initializeHook
-} from 'ember-hook'
+import {beforeEach, describe, it} from 'mocha'
 import wait from 'ember-test-helpers/wait'
 import sinon from 'sinon'
+
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
 const defaultPack = 'app'
 const defaultSelectedPack = 'frost'
@@ -29,349 +24,345 @@ const bodyContentHookName = '-object-details-body-content'
 const objectTabHookName = '-object-tab'
 const relatedObjectTabHookName = '-related-object-tab'
 
-describeComponent(
-  'frost-object-details',
-  'Integration: FrostObjectDetailsComponent',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      initializeHook()
-    })
+const test = integration('frost-object-details')
+describe(test.label, function () {
+  test.setup()
 
-    it('Set hook name', function () {
-      const hookName = 'my-hook'
-      const tabId = 'profile'
-      const relatedTabId = 'devices'
-      this.setProperties({
-        hook: hookName,
-        defaultTabId: tabId,
-        relatedTabId: relatedTabId
-      })
-      this.render(hbs`
-        {{frost-object-details
-          hook=hook
-          defaultTabId=defaultTabId
-          detailTabs=(array
-              (component 'frost-object-tab'
-                id='profile'
-                text='Profile View'
-                content=(component 'object-details-content' color='skyblue' name='profile')
-              )
-            )
-          relatedObjectTabs=(array
-            (component 'frost-related-object-tab'
-              id=relatedTabId
-              icon=(hash
-                name='network-element'
-              )
-              text='Devices'
-              content=(component 'object-details-content' color='coral' name='devices')
+  beforeEach(function () {
+    initializeHook()
+  })
+
+  it('Set hook name', function () {
+    const hookName = 'my-hook'
+    const tabId = 'profile'
+    const relatedTabId = 'devices'
+    this.setProperties({
+      hook: hookName,
+      defaultTabId: tabId,
+      relatedTabId: relatedTabId
+    })
+    this.render(hbs`
+      {{frost-object-details
+        hook=hook
+        defaultTabId=defaultTabId
+        detailTabs=(array
+            (component 'frost-object-tab'
+              id='profile'
+              text='Profile View'
+              content=(component 'object-details-content' color='skyblue' name='profile')
             )
           )
-        }}
-      `)
-
-      return wait()
-        .then(() => {
-          expect($hook(`${hookName}${objectDetailsHookName}`)).to.have.length(1)
-          expect($hook(`${hookName}${objectDetailsContentHookName}`)).to.have.length(1)
-          expect($hook(`${hookName}${detailsObjectTabsHookName}`)).to.have.length(1)
-          expect($hook(`${hookName}${detailsObjectTabHookName}`, { index: 0 })).to.have.length(1)
-          expect($hook(`${hookName}-${tabId}`)).to.have.length(1)
-          expect($hook(`${hookName}-${tabId}${objectTabHookName}`)).to.have.length(1)
-          expect($hook(`${hookName}${bodyContentHookName}`)).to.have.length(1)
-          expect($hook(`${hookName}${detailsRelatedObjectTabsHookName}`)).to.have.length(1)
-          expect($hook(`${hookName}${detailsRelatedObjectTabHookName}`, { index: 0 })).to.have.length(1)
-          expect($hook(`${hookName}-${relatedTabId}`)).to.have.length(1)
-          expect($hook(`${hookName}-${relatedTabId}${relatedObjectTabHookName}`)).to.have.length(1)
-        })
-    })
-
-    it('Select tab by default', function (done) {
-      const selectedTabText = 'Profile View 2'
-      const contentText = 'profile 2'
-      const defaultTabId = 'profile2'
-      this.setProperties({
-        selectedTabText: selectedTabText,
-        defaultTabId: defaultTabId,
-        contentText: contentText
-      })
-      this.render(hbs`
-        {{frost-object-details
-          defaultTabId=defaultTabId
-          detailTabs=(array
-              (component 'frost-object-tab'
-                id='profile'
-                text='Profile View'
-                content=(component 'object-details-content' color='skyblue' name='profile')
-              )
-              (component 'frost-object-tab'
-                id=defaultTabId
-                text=selectedTabText
-                content=(component 'object-details-content' color='skyblue' name=contentText)
-              )
+        relatedObjectTabs=(array
+          (component 'frost-related-object-tab'
+            id=relatedTabId
+            icon=(hash
+              name='network-element'
             )
-        }}
-      `)
+            text='Devices'
+            content=(component 'object-details-content' color='coral' name='devices')
+          )
+        )
+      }}
+    `)
 
-      return wait()
-        .then(() => {
-          expect($hook(detailsObjectTabHookName)).to.have.length(2)
-          expect($hook(detailsObjectTabHookName, { index: 1 }).text().trim()).to.be.equal(selectedTabText)
-          expect($hook(detailsObjectTabHookName, { index: 1 }).find('button.active')).to.have.length(1)
-          expect($hook(detailsObjectTabHookName, { index: 1 })).to.have.length(1)
-          expect($hook(bodyContentHookName).text().trim()).to.be.equal(`This is ${contentText} template`)
-
-          return capture('object-details-selected-tab', done, {
-            targetElement: $hook('-object-details')[0],
-            experimentalSvgs: true
-          })
-        })
-    })
-
-    it('Select related object tab', function (done) {
-      const selectedTabId = 'device'
-      const selectedTabType = 'relatedObjectTab'
-      const selectedTabText = 'Device'
-      const defaultTabId = 'profile'
-      const contentText = 'related devices'
-      this.setProperties({
-        selectedTabId: selectedTabId,
-        selectedTabType: selectedTabType,
-        selectedTabText: selectedTabText,
-        defaultTabId: defaultTabId,
-        contentText: contentText
+    return wait()
+      .then(() => {
+        expect($hook(`${hookName}${objectDetailsHookName}`)).to.have.length(1)
+        expect($hook(`${hookName}${objectDetailsContentHookName}`)).to.have.length(1)
+        expect($hook(`${hookName}${detailsObjectTabsHookName}`)).to.have.length(1)
+        expect($hook(`${hookName}${detailsObjectTabHookName}`, { index: 0 })).to.have.length(1)
+        expect($hook(`${hookName}-${tabId}`)).to.have.length(1)
+        expect($hook(`${hookName}-${tabId}${objectTabHookName}`)).to.have.length(1)
+        expect($hook(`${hookName}${bodyContentHookName}`)).to.have.length(1)
+        expect($hook(`${hookName}${detailsRelatedObjectTabsHookName}`)).to.have.length(1)
+        expect($hook(`${hookName}${detailsRelatedObjectTabHookName}`, { index: 0 })).to.have.length(1)
+        expect($hook(`${hookName}-${relatedTabId}`)).to.have.length(1)
+        expect($hook(`${hookName}-${relatedTabId}${relatedObjectTabHookName}`)).to.have.length(1)
       })
-      this.render(hbs`
-        {{frost-object-details
-          selectedTabId=selectedTabId
-          selectedTabType=selectedTabType
-          defaultTabId=defaultTabId
-          detailTabs=(array
-              (component 'frost-object-tab'
-                id='profile'
-                text='Profile View'
-                content=(component 'object-details-content' color='skyblue' name='profile')
-              )
+  })
+
+  it('Select tab by default', function (done) {
+    const selectedTabText = 'Profile View 2'
+    const contentText = 'profile 2'
+    const defaultTabId = 'profile2'
+    this.setProperties({
+      selectedTabText: selectedTabText,
+      defaultTabId: defaultTabId,
+      contentText: contentText
+    })
+    this.render(hbs`
+      {{frost-object-details
+        defaultTabId=defaultTabId
+        detailTabs=(array
+            (component 'frost-object-tab'
+              id='profile'
+              text='Profile View'
+              content=(component 'object-details-content' color='skyblue' name='profile')
             )
-          relatedObjectTabs=(array
-            (component 'frost-related-object-tab'
-              id=selectedTabId
-              icon=(hash
-                name='network-element'
-              )
+            (component 'frost-object-tab'
+              id=defaultTabId
               text=selectedTabText
-              content=(component 'object-details-content' color='coral' name=contentText)
+              content=(component 'object-details-content' color='skyblue' name=contentText)
             )
           )
-        }}
-      `)
+      }}
+    `)
 
-      return wait()
-        .then(() => {
-          expect($hook(detailsRelatedObjectTabHookName)).to.have.length(1)
-          expect($hook(detailsRelatedObjectTabHookName, { index: 0 }).text().trim()).to.be.equal(selectedTabText)
-          expect($hook(detailsRelatedObjectTabHookName, { index: 0 }).find('button.active')).to.have.length(1)
-          expect($hook(detailsRelatedObjectTabHookName, { index: 0 }).find(iconSelector).attr(iconAttributeName)
-                .indexOf(`/${defaultSelectedPack}.svg#${defaultSelectedIcon}`)).to.be.gt(-1)
+    return wait()
+      .then(() => {
+        expect($hook(detailsObjectTabHookName)).to.have.length(2)
+        expect($hook(detailsObjectTabHookName, { index: 1 }).text().trim()).to.be.equal(selectedTabText)
+        expect($hook(detailsObjectTabHookName, { index: 1 }).find('button.active')).to.have.length(1)
+        expect($hook(detailsObjectTabHookName, { index: 1 })).to.have.length(1)
+        expect($hook(bodyContentHookName).text().trim()).to.be.equal(`This is ${contentText} template`)
 
-          expect($hook(detailsObjectTabHookName)).to.have.length(1)
-          expect($hook(detailsObjectTabHookName).find('.default')).to.have.length(1)
-
-          expect($hook(bodyContentHookName).text().trim()).to.be.equal(`This is ${contentText} template`)
-
-          return capture('object-details-selected-related-obj-tab', done, {
-            targetElement: $hook('-object-details')[0],
-            experimentalSvgs: true
-          })
+        return capture('object-details-selected-tab', done, {
+          targetElement: $hook('-object-details')[0],
+          experimentalSvgs: true
         })
-    })
-
-    it('Only a detail tab', function (done) {
-      const selectedTabId = 'profile'
-      const defaultTabId = 'profile'
-      this.setProperties({
-        selectedTabId: selectedTabId,
-        defaultTabId: defaultTabId
       })
-      this.render(hbs`
-        {{frost-object-details
-          selectedTabId=selectedTabId
-          defaultTabId=defaultTabId
-          detailTabs=(array
-            (component 'frost-object-tab'
-              id=selectedTabId
-              text='Profile View'
-              content=(component 'object-details-content' color='skyblue' name='profile')
-            )
-          )
-        }}
-      `)
+  })
 
-      return wait()
-        .then(() => {
-          expect($hook(detailsObjectTabHookName, { index: 0 })).to.have.length(1)
-          expect($hook(detailsRelatedObjectTabHookName)).to.have.length(0)
-
-          return capture('object-details-with-only-tab', done, {
-            targetElement: $hook('-object-details')[0],
-            experimentalSvgs: true
-          })
-        })
+  it('Select related object tab', function (done) {
+    const selectedTabId = 'device'
+    const selectedTabType = 'relatedObjectTab'
+    const selectedTabText = 'Device'
+    const defaultTabId = 'profile'
+    const contentText = 'related devices'
+    this.setProperties({
+      selectedTabId: selectedTabId,
+      selectedTabType: selectedTabType,
+      selectedTabText: selectedTabText,
+      defaultTabId: defaultTabId,
+      contentText: contentText
     })
-
-    it('Detail tab and related object tab', function (done) {
-      const selectedTabId = 'profile'
-      const defaultTabId = 'profile'
-      const tabText = 'Profile View'
-      const relatedObjectTabText = 'Devices'
-      const iconName = 'network-element'
-      this.setProperties({
-        selectedTabId: selectedTabId,
-        defaultTabId: defaultTabId,
-        tabText: tabText,
-        relatedObjectTabText: relatedObjectTabText,
-        iconName: iconName
-      })
-      this.render(hbs`
-        {{frost-object-details
-          selectedTabId=selectedTabId
-          defaultTabId=defaultTabId
-          detailTabs=(array
-            (component 'frost-object-tab'
-              id=selectedTabId
-              text=tabText
-              content=(component 'object-details-content' color='skyblue' name='profile')
-            )
-          )
-          relatedObjectTabs=(array
-            (component 'frost-related-object-tab'
-              id='devices'
-              icon=(hash
-                name=iconName
-              )
-              text=relatedObjectTabText
-              content=(component 'object-details-content' color='coral' name='related devices')
-            )
-          )
-        }}
-      `)
-
-      return wait()
-        .then(() => {
-          expect($hook(detailsObjectTabHookName)).to.have.length(1)
-          expect($hook(detailsObjectTabHookName, { index: 0 }).text().trim()).to.be.equal(tabText)
-
-          expect($hook(detailsRelatedObjectTabHookName, { index: 0 })).to.have.length(1)
-          expect($hook(detailsRelatedObjectTabHookName, { index: 0 }).find(iconSelector).attr(iconAttributeName)
-                .indexOf(`/${defaultPack}.svg#${iconName}`)).to.be.gt(-1)
-          expect($hook(detailsRelatedObjectTabHookName, { index: 0 }).text().trim()).to.be.equal(relatedObjectTabText)
-
-          return capture('object-details-with-tabs-and-related-obj-tab', done, {
-            targetElement: $hook('-object-details')[0],
-            experimentalSvgs: true
-          })
-        })
-    })
-
-    it('Set content', function () {
-      const defaultTabId = 'profile'
-      this.setProperties({
-        defaultTabId: defaultTabId
-      })
-      this.render(hbs`
-        {{#frost-object-details
-          defaultTabId=defaultTabId
-          detailTabs=(array
-            (component 'frost-object-tab'
-              id='profile'
-              text='Profile View'
-              content=(component 'object-details-content' color='skyblue' name=selectedTabName)
-            )
-          )
-        }}
-        test
-        {{/frost-object-details}}
-      `)
-
-      expect($hook(detailsObjectTabHookName, { index: 0 })).to.have.length(1)
-      expect($hook('-object-details-content').text().trim()).to.be.equal('test')
-    })
-
-    it('Set onChange', function () {
-      const defaultTabId = 'profile'
-      const props = {
-        defaultTabId: defaultTabId,
-        onChange: sinon.spy()
-      }
-      this.setProperties(props)
-      this.render(hbs`
-        {{#frost-object-details
-          onChange=onChange
-          defaultTabId=defaultTabId
-          detailTabs=(array
-            (component 'frost-object-tab'
-              id='profile'
-              text='Profile View'
-              content=(component 'object-details-content' color='skyblue' name=selectedTabName)
-            )
-          )
-        }}
-        test
-        {{/frost-object-details}}
-      `)
-
-      this.$('button').click()
-
-      expect(props.onChange.called).to.be.true
-      props.onChange.reset()
-    })
-
-    it('Set onChange related object tab', function () {
-      const props = {
-        selectedTabId: 'devices',
-        selectedTabType: 'relatedObjectTab',
-        defaultTabId: 'profile',
-        onChange: sinon.spy()
-      }
-      this.setProperties(props)
-      this.render(hbs`
-        {{#frost-object-details
-          selectedTabId=selectedTabId
-          selectedTabType=selectedTabType
-          onChange=onChange
-          defaultTabId=defaultTabId
-          detailTabs=(array
+    this.render(hbs`
+      {{frost-object-details
+        selectedTabId=selectedTabId
+        selectedTabType=selectedTabType
+        defaultTabId=defaultTabId
+        detailTabs=(array
             (component 'frost-object-tab'
               id='profile'
               text='Profile View'
               content=(component 'object-details-content' color='skyblue' name='profile')
             )
           )
-          relatedObjectTabs=(array
-            (component 'frost-related-object-tab'
-              id='devices'
-              icon=(hash
-                name='network-construct'
-              )
-              text='devices'
-              content=(component 'object-details-content' color='coral' name='related devices')
+        relatedObjectTabs=(array
+          (component 'frost-related-object-tab'
+            id=selectedTabId
+            icon=(hash
+              name='network-element'
             )
+            text=selectedTabText
+            content=(component 'object-details-content' color='coral' name=contentText)
           )
-        }}
-        test
-        {{/frost-object-details}}
-      `)
+        )
+      }}
+    `)
 
-      return wait()
-        .then(() => {
-          this.$('.active.frost-button').click()
+    return wait()
+      .then(() => {
+        expect($hook(detailsRelatedObjectTabHookName)).to.have.length(1)
+        expect($hook(detailsRelatedObjectTabHookName, { index: 0 }).text().trim()).to.be.equal(selectedTabText)
+        expect($hook(detailsRelatedObjectTabHookName, { index: 0 }).find('button.active')).to.have.length(1)
+        expect($hook(detailsRelatedObjectTabHookName, { index: 0 }).find(iconSelector).attr(iconAttributeName)
+              .indexOf(`/${defaultSelectedPack}.svg#${defaultSelectedIcon}`)).to.be.gt(-1)
 
-          expect(props.onChange.called).to.be.true
-          props.onChange.reset()
+        expect($hook(detailsObjectTabHookName)).to.have.length(1)
+        expect($hook(detailsObjectTabHookName).find('.default')).to.have.length(1)
+
+        expect($hook(bodyContentHookName).text().trim()).to.be.equal(`This is ${contentText} template`)
+
+        return capture('object-details-selected-related-obj-tab', done, {
+          targetElement: $hook('-object-details')[0],
+          experimentalSvgs: true
         })
+      })
+  })
+
+  it('Only a detail tab', function (done) {
+    const selectedTabId = 'profile'
+    const defaultTabId = 'profile'
+    this.setProperties({
+      selectedTabId: selectedTabId,
+      defaultTabId: defaultTabId
     })
-  }
-)
+    this.render(hbs`
+      {{frost-object-details
+        selectedTabId=selectedTabId
+        defaultTabId=defaultTabId
+        detailTabs=(array
+          (component 'frost-object-tab'
+            id=selectedTabId
+            text='Profile View'
+            content=(component 'object-details-content' color='skyblue' name='profile')
+          )
+        )
+      }}
+    `)
+
+    return wait()
+      .then(() => {
+        expect($hook(detailsObjectTabHookName, { index: 0 })).to.have.length(1)
+        expect($hook(detailsRelatedObjectTabHookName)).to.have.length(0)
+
+        return capture('object-details-with-only-tab', done, {
+          targetElement: $hook('-object-details')[0],
+          experimentalSvgs: true
+        })
+      })
+  })
+
+  it('Detail tab and related object tab', function (done) {
+    const selectedTabId = 'profile'
+    const defaultTabId = 'profile'
+    const tabText = 'Profile View'
+    const relatedObjectTabText = 'Devices'
+    const iconName = 'network-element'
+    this.setProperties({
+      selectedTabId: selectedTabId,
+      defaultTabId: defaultTabId,
+      tabText: tabText,
+      relatedObjectTabText: relatedObjectTabText,
+      iconName: iconName
+    })
+    this.render(hbs`
+      {{frost-object-details
+        selectedTabId=selectedTabId
+        defaultTabId=defaultTabId
+        detailTabs=(array
+          (component 'frost-object-tab'
+            id=selectedTabId
+            text=tabText
+            content=(component 'object-details-content' color='skyblue' name='profile')
+          )
+        )
+        relatedObjectTabs=(array
+          (component 'frost-related-object-tab'
+            id='devices'
+            icon=(hash
+              name=iconName
+            )
+            text=relatedObjectTabText
+            content=(component 'object-details-content' color='coral' name='related devices')
+          )
+        )
+      }}
+    `)
+
+    return wait()
+      .then(() => {
+        expect($hook(detailsObjectTabHookName)).to.have.length(1)
+        expect($hook(detailsObjectTabHookName, { index: 0 }).text().trim()).to.be.equal(tabText)
+
+        expect($hook(detailsRelatedObjectTabHookName, { index: 0 })).to.have.length(1)
+        expect($hook(detailsRelatedObjectTabHookName, { index: 0 }).find(iconSelector).attr(iconAttributeName)
+              .indexOf(`/${defaultPack}.svg#${iconName}`)).to.be.gt(-1)
+        expect($hook(detailsRelatedObjectTabHookName, { index: 0 }).text().trim()).to.be.equal(relatedObjectTabText)
+
+        return capture('object-details-with-tabs-and-related-obj-tab', done, {
+          targetElement: $hook('-object-details')[0],
+          experimentalSvgs: true
+        })
+      })
+  })
+
+  it('Set content', function () {
+    const defaultTabId = 'profile'
+    this.setProperties({
+      defaultTabId: defaultTabId
+    })
+    this.render(hbs`
+      {{#frost-object-details
+        defaultTabId=defaultTabId
+        detailTabs=(array
+          (component 'frost-object-tab'
+            id='profile'
+            text='Profile View'
+            content=(component 'object-details-content' color='skyblue' name=selectedTabName)
+          )
+        )
+      }}
+      test
+      {{/frost-object-details}}
+    `)
+
+    expect($hook(detailsObjectTabHookName, { index: 0 })).to.have.length(1)
+    expect($hook('-object-details-content').text().trim()).to.be.equal('test')
+  })
+
+  it('Set onChange', function () {
+    const defaultTabId = 'profile'
+    const props = {
+      defaultTabId: defaultTabId,
+      onChange: sinon.spy()
+    }
+    this.setProperties(props)
+    this.render(hbs`
+      {{#frost-object-details
+        onChange=onChange
+        defaultTabId=defaultTabId
+        detailTabs=(array
+          (component 'frost-object-tab'
+            id='profile'
+            text='Profile View'
+            content=(component 'object-details-content' color='skyblue' name=selectedTabName)
+          )
+        )
+      }}
+      test
+      {{/frost-object-details}}
+    `)
+
+    this.$('button').click()
+
+    expect(props.onChange.called).to.be.true
+    props.onChange.reset()
+  })
+
+  it('Set onChange related object tab', function () {
+    const props = {
+      selectedTabId: 'devices',
+      selectedTabType: 'relatedObjectTab',
+      defaultTabId: 'profile',
+      onChange: sinon.spy()
+    }
+    this.setProperties(props)
+    this.render(hbs`
+      {{#frost-object-details
+        selectedTabId=selectedTabId
+        selectedTabType=selectedTabType
+        onChange=onChange
+        defaultTabId=defaultTabId
+        detailTabs=(array
+          (component 'frost-object-tab'
+            id='profile'
+            text='Profile View'
+            content=(component 'object-details-content' color='skyblue' name='profile')
+          )
+        )
+        relatedObjectTabs=(array
+          (component 'frost-related-object-tab'
+            id='devices'
+            icon=(hash
+              name='network-construct'
+            )
+            text='devices'
+            content=(component 'object-details-content' color='coral' name='related devices')
+          )
+        )
+      }}
+      test
+      {{/frost-object-details}}
+    `)
+
+    return wait()
+      .then(() => {
+        this.$('.active.frost-button').click()
+
+        expect(props.onChange.called).to.be.true
+        props.onChange.reset()
+      })
+  })
+})

--- a/tests/integration/components/frost-object-tab-test.js
+++ b/tests/integration/components/frost-object-tab-test.js
@@ -1,15 +1,10 @@
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
-import { beforeEach } from 'mocha'
+import {expect} from 'chai'
+import {$hook, initialize as initializeHook} from 'ember-hook'
 import hbs from 'htmlbars-inline-precompile'
-import {
-  $hook,
-  initialize as initializeHook
-} from 'ember-hook'
+import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
 const id = 'my-tab'
 const text = 'my tab text'
@@ -34,127 +29,123 @@ const template = hbs`
     onChange=onChange
   }}`
 
-describeComponent(
-  'frost-object-tab',
-  'Integration: FrostObjectTabComponent',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      initializeHook()
-      this.setProperties({
-        id: id,
-        text: text,
-        selectedTabId: defaultSelectedTabId,
-        selectedTabType: defaultSelectedTabType,
-        defaultTabId: defaultTabId,
-        hook: defaultHook
-      })
+const test = integration('frost-object-tab')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initializeHook()
+    this.setProperties({
+      id: id,
+      text: text,
+      selectedTabId: defaultSelectedTabId,
+      selectedTabType: defaultSelectedTabType,
+      defaultTabId: defaultTabId,
+      hook: defaultHook
     })
+  })
 
-    it('Set hook', function () {
-      const hookName = 'my-hook'
-      this.setProperties({
-        hook: hookName
-      })
-      this.render(template)
-      expect($hook(`${hookName}${detailTabHookName}`, { selected: true })).to.have.length(1)
+  it('Set hook', function () {
+    const hookName = 'my-hook'
+    this.setProperties({
+      hook: hookName
     })
+    this.render(template)
+    expect($hook(`${hookName}${detailTabHookName}`, { selected: true })).to.have.length(1)
+  })
 
-    it('Set parent hook', function () {
-      const hookName = 'my-hook'
-      this.setProperties({
-        parentHook: hookName,
-        id: id,
-        text: text,
-        defaultTabId: defaultTabId
-      })
-      this.render(hbs`
-        {{frost-object-tab
-          parentHook=parentHook
-          id=id
-          text=text
-          defaultTabId=defaultTabId
-          content=(component 'object-details-content' color='skyblue' name=name)
-        }}`)
-      expect($hook(`${hookName}-${id}`)).to.have.length(1)
-      expect($hook(`${hookName}-${id}${detailTabHookName}`, { selected: true })).to.have.length(1)
+  it('Set parent hook', function () {
+    const hookName = 'my-hook'
+    this.setProperties({
+      parentHook: hookName,
+      id: id,
+      text: text,
+      defaultTabId: defaultTabId
     })
+    this.render(hbs`
+      {{frost-object-tab
+        parentHook=parentHook
+        id=id
+        text=text
+        defaultTabId=defaultTabId
+        content=(component 'object-details-content' color='skyblue' name=name)
+      }}`)
+    expect($hook(`${hookName}-${id}`)).to.have.length(1)
+    expect($hook(`${hookName}-${id}${detailTabHookName}`, { selected: true })).to.have.length(1)
+  })
 
-    it('Set text', function () {
-      const text = 'bla bla bla'
-      this.setProperties({
-        text: text
-      })
-      this.render(template)
-      expect($hook(`${detailTabHookName}`, { selected: true }).text().trim()).to.be.equal(text)
+  it('Set text', function () {
+    const text = 'bla bla bla'
+    this.setProperties({
+      text: text
     })
+    this.render(template)
+    expect($hook(`${detailTabHookName}`, { selected: true }).text().trim()).to.be.equal(text)
+  })
 
-    it('No tab selected', function () {
-      this.setProperties({
-        selectedTabId: null
-      })
-      this.render(template)
-      expect($hook(`${detailTabHookName}`, { selected: true })).to.have.length(1)
+  it('No tab selected', function () {
+    this.setProperties({
+      selectedTabId: null
     })
+    this.render(template)
+    expect($hook(`${detailTabHookName}`, { selected: true })).to.have.length(1)
+  })
 
-    it('No type selected', function () {
-      this.setProperties({
-        selectedTabType: null
-      })
-      this.render(template)
-      expect($hook(`${detailTabHookName}`, { selected: true })).to.have.length(1)
+  it('No type selected', function () {
+    this.setProperties({
+      selectedTabType: null
     })
+    this.render(template)
+    expect($hook(`${detailTabHookName}`, { selected: true })).to.have.length(1)
+  })
 
-    it('Is default tab and different tab selected', function () {
-      this.setProperties({
-        defaultTabId: id,
-        selectedTabId: 'abc',
-        selectedTabType: 'abc'
-      })
-      this.render(template)
-      expect($hook(`${detailTabHookName}`, { selected: false }).find('button.active')).to.have.length(0)
-      expect($hook(`${detailTabHookName}`, { selected: true })).to.have.length(0)
-      expect($hook(`${detailTabHookName}`, { selected: false })).to.have.length(1)
-      expect($hook(`${detailTabHookName}`, { selected: false }).find('button.default')).to.have.length(1)
+  it('Is default tab and different tab selected', function () {
+    this.setProperties({
+      defaultTabId: id,
+      selectedTabId: 'abc',
+      selectedTabType: 'abc'
     })
+    this.render(template)
+    expect($hook(`${detailTabHookName}`, { selected: false }).find('button.active')).to.have.length(0)
+    expect($hook(`${detailTabHookName}`, { selected: true })).to.have.length(0)
+    expect($hook(`${detailTabHookName}`, { selected: false })).to.have.length(1)
+    expect($hook(`${detailTabHookName}`, { selected: false }).find('button.default')).to.have.length(1)
+  })
 
-    it('Is default tab and is selected', function () {
-      this.setProperties({
-        defaultTabId: id,
-        selectedTabId: id
-      })
-      this.render(template)
-      expect($hook(`${detailTabHookName}`, { selected: true }).find('button.active')).to.have.length(1)
-      expect($hook(`${detailTabHookName}`, { selected: true })).to.have.length(1)
-      expect($hook(`${detailTabHookName}`, { selected: false })).to.have.length(0)
-      expect($hook(`${detailTabHookName}`, { selected: false }).find('button.default')).to.have.length(0)
+  it('Is default tab and is selected', function () {
+    this.setProperties({
+      defaultTabId: id,
+      selectedTabId: id
     })
+    this.render(template)
+    expect($hook(`${detailTabHookName}`, { selected: true }).find('button.active')).to.have.length(1)
+    expect($hook(`${detailTabHookName}`, { selected: true })).to.have.length(1)
+    expect($hook(`${detailTabHookName}`, { selected: false })).to.have.length(0)
+    expect($hook(`${detailTabHookName}`, { selected: false }).find('button.default')).to.have.length(0)
+  })
 
-    it('Is selected', function () {
-      this.setProperties({
-        defaultTabId: 'abc',
-        selectedTabId: id
-      })
-      this.render(template)
-      expect($hook(`${detailTabHookName}`, { selected: true }).find('button.active')).to.have.length(1)
-      expect($hook(`${detailTabHookName}`, { selected: true })).to.have.length(1)
+  it('Is selected', function () {
+    this.setProperties({
+      defaultTabId: 'abc',
+      selectedTabId: id
     })
+    this.render(template)
+    expect($hook(`${detailTabHookName}`, { selected: true }).find('button.active')).to.have.length(1)
+    expect($hook(`${detailTabHookName}`, { selected: true })).to.have.length(1)
+  })
 
-    it('Set onChange', function () {
-      const defaultTabId = id
-      const props = {
-        defaultTabId: defaultTabId,
-        onChange: sinon.spy()
-      }
-      this.setProperties(props)
-      this.render(template)
+  it('Set onChange', function () {
+    const defaultTabId = id
+    const props = {
+      defaultTabId: defaultTabId,
+      onChange: sinon.spy()
+    }
+    this.setProperties(props)
+    this.render(template)
 
-      this.$('button').click()
+    this.$('button').click()
 
-      expect(props.onChange.called).to.be.true
-      props.onChange.reset()
-    })
-  }
-)
+    expect(props.onChange.called).to.be.true
+    props.onChange.reset()
+  })
+})

--- a/tests/integration/components/frost-related-object-tab-test.js
+++ b/tests/integration/components/frost-related-object-tab-test.js
@@ -1,16 +1,11 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
-import { beforeEach } from 'mocha'
+import {expect} from 'chai'
+import {$hook, initialize as initializeHook} from 'ember-hook'
 import hbs from 'htmlbars-inline-precompile'
-import {
-  $hook,
-  initialize as initializeHook
-} from 'ember-hook'
+import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
 const defaultPack = 'app'
 const defaultSelectedPack = 'frost'
@@ -47,101 +42,97 @@ const template = hbs`{{frost-related-object-tab
     onChange=onChange
   }}`
 
-describeComponent(
-  'frost-related-object-tab',
-  'Integration: FrostRelatedObjectTabComponent',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      initializeHook()
-      this.setProperties({
-        id: id,
-        text: text,
-        selectedTabId: defaultSelectedTabId,
-        selectedTabType: defaultSelectedTabType,
-        icon: iconWithNameOnly,
-        hook: defaultHook
-      })
+const test = integration('frost-related-object-tab')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initializeHook()
+    this.setProperties({
+      id: id,
+      text: text,
+      selectedTabId: defaultSelectedTabId,
+      selectedTabType: defaultSelectedTabType,
+      icon: iconWithNameOnly,
+      hook: defaultHook
     })
+  })
 
-    it('Set hook', function () {
-      const hookName = 'my-hook'
-      this.setProperties({
-        hook: hookName
-      })
-      this.render(template)
-      expect($hook(`${hookName}${relatedObjectTabHookName}`, { selected: true })).to.have.length(1)
+  it('Set hook', function () {
+    const hookName = 'my-hook'
+    this.setProperties({
+      hook: hookName
     })
+    this.render(template)
+    expect($hook(`${hookName}${relatedObjectTabHookName}`, { selected: true })).to.have.length(1)
+  })
 
-    it('Set parent hook', function () {
-      const hookName = 'my-hook'
-      this.setProperties({
-        parentHook: hookName,
-        id: id,
-        text: text
-      })
-      this.render(hbs`{{frost-related-object-tab
-        parentHook=parentHook
-        id=id
-        text=text
-        content=(component 'object-details-content' color='skyblue' name=name)
-      }}`)
-      expect($hook(`${hookName}-${id}`)).to.have.length(1)
-      expect($hook(`${hookName}-${id}${relatedObjectTabHookName}`, { selected: false })).to.have.length(1)
+  it('Set parent hook', function () {
+    const hookName = 'my-hook'
+    this.setProperties({
+      parentHook: hookName,
+      id: id,
+      text: text
     })
+    this.render(hbs`{{frost-related-object-tab
+      parentHook=parentHook
+      id=id
+      text=text
+      content=(component 'object-details-content' color='skyblue' name=name)
+    }}`)
+    expect($hook(`${hookName}-${id}`)).to.have.length(1)
+    expect($hook(`${hookName}-${id}${relatedObjectTabHookName}`, { selected: false })).to.have.length(1)
+  })
 
-    it('Set text', function () {
-      const text = 'bla bla bla'
-      this.setProperties({
-        text: text
-      })
-      this.render(template)
-      expect($hook(`${relatedObjectTabHookName}`, { selected: true }).text().trim()).to.be.equal(text)
+  it('Set text', function () {
+    const text = 'bla bla bla'
+    this.setProperties({
+      text: text
     })
+    this.render(template)
+    expect($hook(`${relatedObjectTabHookName}`, { selected: true }).text().trim()).to.be.equal(text)
+  })
 
-    it('Set icon name', function () {
-      this.setProperties({
-        selectedTabId: 'abc'
-      })
-      this.render(template)
-      expect($hook(`${relatedObjectTabHookName}`, { selected: false }).find(iconSelector).attr(iconAttributeName)
-            .indexOf(`/${defaultPack}.svg#${iconWithNameOnly.name}`)).to.be.gt(-1)
+  it('Set icon name', function () {
+    this.setProperties({
+      selectedTabId: 'abc'
     })
+    this.render(template)
+    expect($hook(`${relatedObjectTabHookName}`, { selected: false }).find(iconSelector).attr(iconAttributeName)
+          .indexOf(`/${defaultPack}.svg#${iconWithNameOnly.name}`)).to.be.gt(-1)
+  })
 
-    it('Set icon name and pack', function () {
-      this.setProperties({
-        selectedTabId: 'abc',
-        icon: icon
-      })
-      this.render(template)
-      expect($hook(`${relatedObjectTabHookName}`, { selected: false }).find(iconSelector).attr(iconAttributeName)
-            .indexOf(`/${icon.pack}.svg#${icon.name}`)).to.be.gt(-1)
+  it('Set icon name and pack', function () {
+    this.setProperties({
+      selectedTabId: 'abc',
+      icon: icon
     })
+    this.render(template)
+    expect($hook(`${relatedObjectTabHookName}`, { selected: false }).find(iconSelector).attr(iconAttributeName)
+          .indexOf(`/${icon.pack}.svg#${icon.name}`)).to.be.gt(-1)
+  })
 
-    it('Tab is selected', function () {
-      this.render(template)
-      expect($hook(`${relatedObjectTabHookName}`, { selected: true }).find('button.active')).to.have.length(1)
-      expect($hook(`${relatedObjectTabHookName}`, { selected: true }).find(iconSelector).attr(iconAttributeName)
-            .indexOf(`/${defaultSelectedPack}.svg#${defaultSelectedIcon}`)).to.be.gt(-1)
-    })
+  it('Tab is selected', function () {
+    this.render(template)
+    expect($hook(`${relatedObjectTabHookName}`, { selected: true }).find('button.active')).to.have.length(1)
+    expect($hook(`${relatedObjectTabHookName}`, { selected: true }).find(iconSelector).attr(iconAttributeName)
+          .indexOf(`/${defaultSelectedPack}.svg#${defaultSelectedIcon}`)).to.be.gt(-1)
+  })
 
-    it('Set onChange', function () {
-      const defaultTabId = id
-      const props = {
-        defaultTabId: defaultTabId,
-        selectedTabId: 'abc',
-        onChange: sinon.spy()
-      }
+  it('Set onChange', function () {
+    const defaultTabId = id
+    const props = {
+      defaultTabId: defaultTabId,
+      selectedTabId: 'abc',
+      onChange: sinon.spy()
+    }
 
-      this.setProperties(props)
-      this.render(template)
+    this.setProperties(props)
+    this.render(template)
 
-      this.$('button').click()
+    this.$('button').click()
 
-      expect(props.onChange.called).to.be.true
-      props.onChange.reset()
-    })
-  }
-)
+    expect(props.onChange.called).to.be.true
+    props.onChange.reset()
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-object-details/issues/34

# CHANGELOG
* **Updated** integration tests to remove the deprecated use of `describeComponent()`
