### PR TITLE
Hide the divider when details tab isVisible=false

### DIFF
--- a/addon/styles/_frost-object-details.scss
+++ b/addon/styles/_frost-object-details.scss
@@ -13,7 +13,7 @@ $frost-object-details-line-between-tab-bg: $frost-color-lgrey-2;
     font-size: 0;
 
     .object-details-tab {
-      &:last-child {
+      &:first-child {
         .object-tab-divider {
           height: 0;
         }

--- a/addon/styles/_frost-object-details.scss
+++ b/addon/styles/_frost-object-details.scss
@@ -13,9 +13,13 @@ $frost-object-details-line-between-tab-bg: $frost-color-lgrey-2;
     font-size: 0;
 
     .object-details-tab {
-      &:first-child {
+      .object-tab-divider {
+        display: none;
+      }
+
+      + .object-details-tab {
         .object-tab-divider {
-          height: 0;
+          display: block;
         }
       }
     }

--- a/addon/templates/components/frost-object-tab.hbs
+++ b/addon/templates/components/frost-object-tab.hbs
@@ -1,10 +1,10 @@
 <div class='object-tab' data-test={{hook (concat hook '-object-tab') selected=isSelected }}>
+  <div class='object-tab-divider'></div>
   {{frost-button
     class=(concat 'tab' (if isSelected ' active') (if isDefault ' default'))
     disabled=disabled
     text=text
     onClick=(action 'change')}}
-  <div class='object-tab-divider'></div>
 </div>
 
 {{#if isSelected}}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* Hide object details tab divider when a tab is set as `isVisible=false`