### PR TITLE
Upgrade ember-cli 2.12.3 inter-dependencies

### DIFF
--- a/blueprints/ember-frost-object-details/index.js
+++ b/blueprints/ember-frost-object-details/index.js
@@ -3,7 +3,7 @@ const blueprintHelper = require('ember-frost-core/blueprint-helper')
 module.exports = {
   afterInstall: function (options) {
     const addonsToAdd = [
-      {name: 'ember-frost-core', target: '^1.14.3'}
+      {name: 'ember-frost-core', target: '1.23.10'}
     ]
 
     // Get the packages installed in the consumer app/addon. Packages that are already installed in the consumer within

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-chai": "0.3.2",
     "ember-cli-code-coverage": "0.3.5",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "0.3.12",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mirage": "0.2.2",
     "ember-cli-mocha": "0.14.4",
@@ -66,10 +66,10 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-sass": "^5.6.0",
-    "ember-frost-core": "^1.14.3",
-    "ember-simple-uuid": "^0.1.4",
-    "liquid-fire": "~0.27.3"
+    "ember-cli-sass": "5.6.0",
+    "ember-frost-core": "1.23.10",
+    "ember-simple-uuid": "0.1.4",
+    "liquid-fire": "0.27.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Upgrade ember-cli 2.12.3 inter-dependencies