### PR TITLE
Refactor to remove ember-simple-uuid dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ matrix:
 
 before_install:
 - npm config set spin false
-- npm install -g bower
 - npm install -g coveralls pr-bumper@^1.0.0
 - $(npm root -g)/pr-bumper/.travis/maybe-check-scope.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
 
 before_install:
 - npm config set spin false
+- npm install -g bower
 - npm install -g coveralls pr-bumper@^1.0.0
 - $(npm root -g)/pr-bumper/.travis/maybe-check-scope.sh
 

--- a/addon/components/frost-object-details.js
+++ b/addon/components/frost-object-details.js
@@ -1,8 +1,7 @@
 import Ember from 'ember'
-const {Component, computed, get, set} = Ember
+const {Component, computed, get, guidFor, set} = Ember
 import layout from '../templates/components/frost-object-details'
 import PropTypesMixin, {PropTypes} from 'ember-prop-types'
-import uuid from 'ember-simple-uuid'
 
 export default Component.extend(PropTypesMixin, {
   // == Component properties ==================================================
@@ -27,7 +26,7 @@ export default Component.extend(PropTypesMixin, {
 
   getDefaultProps () {
     return {
-      targetOutlet: `tab-content-${uuid()}`
+      targetOutlet: `tab-content-${guidFor({})}`
     }
   },
 

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,6 @@
     "pretender": "~0.12.0",
     "sinonjs": "1.17.1",
     "es6-promise": "^4.0.3",
-    "resemblejs": "^2.2.2",
-    "node-uuid": "1.4.7"
+    "resemblejs": "^2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "5.6.0",
     "ember-frost-core": "^3.0.1",
-    "ember-simple-uuid": "0.1.4",
     "liquid-fire": "0.27.3"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
     "chai-jquery": "^2.0.0",
     "ember-browserify": "1.1.13",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Refactor to remove `ember-simple-uuid` dependency